### PR TITLE
[#9] Use expiringdict to cache objects for v1

### DIFF
--- a/helga_versionone/v1_wrapper.py
+++ b/helga_versionone/v1_wrapper.py
@@ -6,6 +6,7 @@ import httplib2
 from urllib import urlencode
 
 
+from expiringdict import ExpiringDict
 from functools import wraps
 from urlparse import urlparse
 from v1pysdk.client import V1Server
@@ -46,7 +47,8 @@ class HelgaV1Meta(V1Meta):  # pragma: no cover
     def __init__(self, *args, **kw):
         # Coppied from V1Meta, but use our own Server class
         self.server = HelgaOauthV1Server(*args, **kw)
-        self.global_cache = {}
+        # ...And a cache that expires
+        self.global_cache = ExpiringDict(max_len=100, max_age_seconds=10)
         self.dirtylist = []
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,11 @@
 # For the v1pysdk requirements
 --allow-external elementtree
 --allow-unverified elementtree
-v1pysdk-unofficial==0.4.post1
+v1pysdk-unofficial==0.4.post2
 
 helga==1.6.3
 Twisted==13.1.0
 pymongo==2.5.2
 httplib2==0.9
 oauth2client==1.4.5
+expiringdict==1.1.3

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(name="helga-versionone",
       install_requires=[
           'v1pysdk-unofficial',
           'oauth2client',
+          'expiringdict',
       ],
       entry_points = dict(
           helga_plugins=[

--- a/tox.ini
+++ b/tox.ini
@@ -11,3 +11,8 @@ deps =
 sitepackages = False
 commands =
     py.test -q --cov-config .coveragerc --cov helga_versionone --cov-report term-missing
+
+[testenv:py26]
+deps =
+    {[testenv]deps}
+    ordereddict


### PR DESCRIPTION
Replace the Server's global_cache with an instance of ExpiringDict
It will hold 100 items for upto 10 seconds. This will give us generally
up to date data when changes are made in V1's web interface.

A Version bump was required to v1pysdk to prevent a race condition

ExpiringDict requires OrderedDict which exists only in py27, so tox will
install the backport ordereddict from pypi when testing on py26