### PR TITLE
Add VERSIONONE_SHARED_TOKEN, convenience

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Installation
 Using pip
 ---------
 
-pip install --allow-external elementtree --allow-unverified elementtree helga-versionone
+`pip install --allow-external elementtree --allow-unverified elementtree helga-versionone`
 
 If you're wondering what the ``--allow-external elementtree``
 and ``--allow-unverified elementree`` lines are about:
@@ -17,8 +17,6 @@ This program relies upon the
 `Python SDK released by the VersionOne team <https://github.com/versionone/VersionOne.SDK.Python>`
 (albeit, an unofficial distribution of it), and that SDK relies upon elementree
 which is unavailable through verified/local PyPI sources.
-
-On py26 you'll need to pip install ordereddict
 
 
 Settings to Add
@@ -33,6 +31,7 @@ You'll need these in your settings.py
  * __VERSIONONE_OAUTH_CLIENT_ID__  From your Oauth client.
  * __VERSIONONE_OAUTH_CLIENT_SECRET__ From your Oauth client.
  * __VERSIONONE_OAUTH_ENABLED__ (Default: False) Set to True to enable Oauth.
+ * __VERSIONONE_SHARED_TOKEN__ Set token for read-only type operations, like listing story info
 
 Commands
 ========

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 # For the v1pysdk requirements
 v1pysdk-unofficial==0.4.post4
 
-helga>=1.6.0
-Twisted>=13.1.0
-pymongo>=2.5.2
-httplib2>=0.9.2
-oauth2client>=2.0.1
-expiringdict>=1.1.3
+helga==1.7.5
+Twisted==16.6.0
+pymongo==3.4.0
+httplib2==0.9.2
+oauth2client==4.0.0
+expiringdict==1.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@
 v1pysdk-unofficial==0.4.post4
 
 helga>=1.6.0
-Twisted==13.1.0
-pymongo==2.5.2
-httplib2==0.9.2
-oauth2client==2.0.1
-expiringdict==1.1.3
+Twisted>=13.1.0
+pymongo>=2.5.2
+httplib2>=0.9.2
+oauth2client>=2.0.1
+expiringdict>=1.1.3

--- a/setup.py
+++ b/setup.py
@@ -1,39 +1,39 @@
 from setuptools import setup, find_packages
 
 
-version = '0.1.9'
+version = '0.1.10'
 
-setup(name="helga-versionone",
-      version=version,
-      description=('VersionOne interface for helga chat bot'),
-      classifiers=[
-          'Development Status :: 4 - Beta',
-          'Topic :: Communications :: Chat :: Internet Relay Chat',
-          'Framework :: Twisted',
-          'License :: OSI Approved :: MIT License',
-          'Operating System :: OS Independent',
-          'Programming Language :: Python',
-          'Programming Language :: Python :: 2',
-          'Programming Language :: Python :: 2.6',
-          'Programming Language :: Python :: 2.7',
-          'Topic :: Software Development :: Libraries :: Python Modules',
-      ],
-      keywords='helga versionone',
-      author='Aaron McMillin',
-      author_email='aaron@mcmillinclan.org',
-      url='https://github.com/aarcro/helga-versionone',
-      download_url='https://github.com/aarcro/helga-versionone/tarball/' + version,
-      license='MIT',
-      packages=find_packages(),
-      py_modules=['helga_versionone'],
-      install_requires=[
-          'v1pysdk-unofficial',
-          'oauth2client',
-          'expiringdict',
-      ],
-      entry_points = dict(
-          helga_plugins=[
-              'versionone = helga_versionone:versionone'
-          ],
-      ),
+setup(
+    name="helga-versionone",
+    version=version,
+    description=('VersionOne interface for helga chat bot'),
+    classifiers=[
+        'Development Status :: 4 - Beta',
+        'Topic :: Communications :: Chat :: Internet Relay Chat',
+        'Framework :: Twisted',
+        'License :: OSI Approved :: MIT License',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Topic :: Software Development :: Libraries :: Python Modules',
+    ],
+    keywords='helga versionone',
+    author='Aaron McMillin',
+    author_email='aaron@mcmillinclan.org',
+    url='https://github.com/aarcro/helga-versionone',
+    download_url='https://github.com/aarcro/helga-versionone/tarball/' + version,
+    license='MIT',
+    packages=find_packages(),
+    py_modules=['helga_versionone'],
+    install_requires=[
+        'v1pysdk-unofficial',
+        'oauth2client',
+        'expiringdict',
+    ],
+    entry_points=dict(
+        helga_plugins=[
+            'versionone = helga_versionone:versionone'
+        ],
+    ),
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27
+envlist = py27
 
 [testenv]
 deps =
@@ -11,8 +11,3 @@ deps =
 sitepackages = False
 commands =
     py.test -q --cov-config .coveragerc --cov helga_versionone --cov-report term-missing
-
-[testenv:py26]
-deps =
-    {[testenv]deps}
-    ordereddict


### PR DESCRIPTION
### Description
* Add VERSIONONE_SHARED_TOKEN which can be used for information/read only purposes
The rest is minor IMO:
* Use py27 only
* Unpinning some (old) repos
* pep8ing setup.py more
* Increment version

### Testing
* Run tox, passes
* Run in my own test environment. A user with no v1 token set may still get information back if shred token is set in settings.

@aarcro 